### PR TITLE
began adding additional language support #14

### DIFF
--- a/app/src/main/java/programmingtools/MainActivityQR.kt
+++ b/app/src/main/java/programmingtools/MainActivityQR.kt
@@ -19,6 +19,7 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
+import androidx.annotation.StringRes
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.qrcode.QRCodeWriter
 import java.io.File
@@ -27,18 +28,18 @@ import java.io.IOException
 
 class MainActivity : ComponentActivity() {
     private enum class SaveFormat(
-        val displayName: String,
+        @param:StringRes val labelResId: Int,
         val fileExtension: String,
         val mimeType: String,
         val compressFormat: Bitmap.CompressFormat
     ) {
-        PNG("PNG", "png", "image/png", Bitmap.CompressFormat.PNG),
-        JPEG("JPEG", "jpg", "image/jpeg", Bitmap.CompressFormat.JPEG),
-        WEBP("WEBP", "webp", "image/webp", Bitmap.CompressFormat.WEBP);
+        PNG(R.string.save_format_png, "png", "image/png", Bitmap.CompressFormat.PNG),
+        JPEG(R.string.save_format_jpeg, "jpg", "image/jpeg", Bitmap.CompressFormat.JPEG),
+        WEBP(R.string.save_format_webp, "webp", "image/webp", Bitmap.CompressFormat.WEBP);
 
         companion object {
-            fun fromDisplayName(value: String): SaveFormat {
-                return entries.firstOrNull { it.displayName == value } ?: PNG
+            fun fromLocalizedLabel(value: String, resolver: (Int) -> String): SaveFormat {
+                return entries.firstOrNull { resolver(it.labelResId) == value } ?: PNG
             }
         }
     }
@@ -102,7 +103,12 @@ class MainActivity : ComponentActivity() {
         textViewSelectedColor = findViewById(R.id.textViewSelectedColor)
         textViewPreviewStatus = findViewById(R.id.textViewPreviewStatus)
 
-        updateSelectedSaveFormat(SaveFormat.fromDisplayName(getString(R.string.default_save_format)))
+        updateSelectedSaveFormat(
+            SaveFormat.fromLocalizedLabel(
+                getString(R.string.default_save_format),
+                ::getString
+            )
+        )
         updateSelectedColor(Color.parseColor(getString(R.string.default_qr_color)))
         updatePreviewState(hasPreview = false)
 
@@ -148,7 +154,7 @@ class MainActivity : ComponentActivity() {
         }
 
         buttonViewSample.setOnClickListener {
-            val sampleText = "Sample QR Code"
+            val sampleText = getString(R.string.sample_qr_text)
             val sampleSize = 256
             val sampleColor = selectedColor
             val sampleBitmap =
@@ -210,7 +216,7 @@ class MainActivity : ComponentActivity() {
         super.onSaveInstanceState(outState)
         outState.putString(STATE_TEXT, editText.text.toString())
         outState.putString(STATE_SIZE, editTextSize.text.toString())
-        outState.putString(STATE_SAVE_FORMAT, selectedSaveFormat().displayName)
+        outState.putString(STATE_SAVE_FORMAT, getString(selectedSaveFormat().labelResId))
         outState.putString(STATE_SAVE_TEXT, editTextSaveText.text.toString())
         outState.putString(STATE_COLOR, formatColor(selectedColor))
         outState.putBoolean(STATE_HAS_QR, generatedBitmap != null)
@@ -246,7 +252,10 @@ class MainActivity : ComponentActivity() {
 
     private fun restoreSaveFormat(value: String) {
         updateSelectedSaveFormat(
-            SaveFormat.fromDisplayName(value.ifBlank { getString(R.string.default_save_format) })
+            SaveFormat.fromLocalizedLabel(
+                value.ifBlank { getString(R.string.default_save_format) },
+                ::getString
+            )
         )
     }
 
@@ -258,7 +267,7 @@ class MainActivity : ComponentActivity() {
         currentSaveFormat = saveFormat
         textViewSelectedSaveFormat.text = getString(
             R.string.selected_save_format_format,
-            saveFormat.displayName
+            getString(saveFormat.labelResId)
         )
     }
 
@@ -361,7 +370,7 @@ class MainActivity : ComponentActivity() {
 
     private fun showSaveFormatDialog() {
         val formats = SaveFormat.entries.toTypedArray()
-        val labels = formats.map { it.displayName }.toTypedArray()
+        val labels = formats.map { getString(it.labelResId) }.toTypedArray()
         val selectedIndex = formats.indexOf(selectedSaveFormat()).coerceAtLeast(0)
 
         AlertDialog.Builder(this)
@@ -369,7 +378,10 @@ class MainActivity : ComponentActivity() {
             .setSingleChoiceItems(labels, selectedIndex) { dialog, which ->
                 updateSelectedSaveFormat(formats[which])
                 announceAccessibilityMessage(
-                    getString(R.string.save_format_changed_announcement, formats[which].displayName)
+                    getString(
+                        R.string.save_format_changed_announcement,
+                        getString(formats[which].labelResId)
+                    )
                 )
                 dialog.dismiss()
             }

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -1,0 +1,64 @@
+<resources>
+    <string name="app_name">ProgrammingTools</string>
+    <string name="screen_title">Estudio de Códigos QR</string>
+    <string name="screen_subtitle">Crea, previsualiza y guarda códigos QR personalizados en pocos toques.</string>
+    <string name="screen_subtitle_accessibility">Crea, previsualiza, guarda y comparte códigos QR personalizados.</string>
+    <string name="enter_text_for_qr_code">Ingresa el texto para el código QR</string>
+    <string name="text_field_label">Texto para codificar</string>
+    <string name="enter_size_hint">Ingresa el tamaño (por ejemplo, 512)</string>
+    <string name="size_field_label">Tamaño de salida</string>
+    <string name="save_format_label">Formato de guardado</string>
+    <string name="enter_text_to_save_beneath_the_image">Ingresa el texto para guardar debajo de la imagen</string>
+    <string name="save_text_field_label">Texto bajo la imagen</string>
+    <string name="color_picker_label">Color del código QR</string>
+    <string name="choose_color">Elegir color</string>
+    <string name="default_qr_size">256</string>
+    <string name="default_save_text">Escanéame</string>
+    <string name="default_qr_color">#000000</string>
+    <string name="default_save_format">PNG</string>
+    <string name="sample_qr_text">Código QR de muestra</string>
+    <string name="save_format_png">PNG</string>
+    <string name="save_format_jpeg">JPEG</string>
+    <string name="save_format_webp">WEBP</string>
+    <string name="generate_qr_code">Generar código QR</string>
+    <string name="save_qr_code">Guardar código QR</string>
+    <string name="share_qr_code">Compartir código QR</string>
+    <string name="view_image_sample">Ver ejemplo</string>
+    <string name="image_description">Imagen del código QR</string>
+    <string name="preview_unavailable">Aún no hay vista previa del código QR.</string>
+    <string name="selected_save_format_format">Formato seleccionado: %1$s</string>
+    <string name="selected_color_accessibility_format">Color seleccionado del código QR: %1$s</string>
+    <string name="pick_color_accessibility">Abrir el selector de color del código QR</string>
+    <string name="pick_save_format_accessibility">Elegir el formato de archivo usado al guardar el código QR</string>
+    <string name="share_button_accessibility">Compartir la imagen actual del código QR</string>
+    <string name="save_button_accessibility">Guardar el código QR actual en tu dispositivo</string>
+    <string name="sample_button_accessibility">Generar una vista previa de ejemplo del código QR</string>
+    <string name="generate_button_accessibility">Generar un código QR con el texto actual</string>
+    <string name="qr_generated_announcement">Código QR generado y vista previa actualizada.</string>
+    <string name="sample_generated_announcement">Código QR de muestra generado.</string>
+    <string name="save_format_changed_announcement">El formato de guardado cambió a %1$s.</string>
+    <string name="color_changed_announcement">El color del código QR cambió a %1$s.</string>
+    <string name="share_started_announcement">Abriendo opciones para compartir el código QR actual.</string>
+    <string name="save_started_announcement">Elige dónde guardar el código QR actual.</string>
+    <string name="image_saved_announcement">La imagen del código QR se guardó correctamente.</string>
+    <string name="enter_text_error">Ingresa texto antes de generar un código QR.</string>
+    <string name="generate_before_saving">Genera o carga un código QR antes de guardarlo.</string>
+    <string name="default_qr_filename">QRCode.png</string>
+    <string name="image_saved_successfully">Imagen guardada correctamente</string>
+    <string name="share_image_error">Error al compartir la imagen: %1$s</string>
+    <string name="generate_before_sharing">Genera o carga un código QR antes de compartirlo.</string>
+    <string name="share_qr_chooser_title">Compartir código QR</string>
+    <string name="error_saving_image">Error al guardar la imagen: %1$s</string>
+    <string name="color_picker_title">Elegir color del QR</string>
+    <string name="save_format_picker_title">Elegir formato de guardado</string>
+    <string name="red_label">Rojo</string>
+    <string name="green_label">Verde</string>
+    <string name="blue_label">Azul</string>
+    <string name="selected_color_format">Seleccionado: %1$s</string>
+    <string name="preview_section_label">Vista previa</string>
+    <string-array name="save_format_options">
+        <item>@string/save_format_png</item>
+        <item>@string/save_format_jpeg</item>
+        <item>@string/save_format_webp</item>
+    </string-array>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,6 +16,10 @@
     <string name="default_save_text">Scan Me</string>
     <string name="default_qr_color">#000000</string>
     <string name="default_save_format">PNG</string>
+    <string name="sample_qr_text">Sample QR Code</string>
+    <string name="save_format_png">PNG</string>
+    <string name="save_format_jpeg">JPEG</string>
+    <string name="save_format_webp">WEBP</string>
     <string name="generate_qr_code">Generate QR Code</string>
     <string name="save_qr_code">Save QR Code</string>
     <string name="share_qr_code">Share QR Code</string>
@@ -53,8 +57,8 @@
     <string name="selected_color_format">Selected: %1$s</string>
     <string name="preview_section_label">Preview</string>
     <string-array name="save_format_options">
-        <item>PNG</item>
-        <item>JPEG</item>
-        <item>WEBP</item>
+        <item>@string/save_format_png</item>
+        <item>@string/save_format_jpeg</item>
+        <item>@string/save_format_webp</item>
     </string-array>
 </resources>


### PR DESCRIPTION
This is a real first pass on #14, but I’d still call the issue only partially addressed overall. The app now has localization infrastructure plus one additional language, but “support multiple languages” usually also means:

- adding more locales beyond Spanish
- checking layout fit for translated text on phone and tablet
- reviewing phrasing with a native speaker
- localizing README/store-facing copy if that’s part of the release workflow