### PR TITLE
adds initial app telemetry #15

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name=".QRCodeGeniusApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/programmingtools/AppTelemetry.kt
+++ b/app/src/main/java/programmingtools/AppTelemetry.kt
@@ -1,0 +1,85 @@
+package com.programmingtools.app
+
+import android.content.Context
+import android.util.Log
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+object AppTelemetry {
+    private const val TAG = "AppTelemetry"
+    private const val EVENTS_LOG_FILE = "events.log"
+    private const val CRASH_LOG_FILE = "crashes.log"
+    private var appContext: Context? = null
+    private var initialized = false
+
+    fun initialize(context: Context) {
+        if (initialized) {
+            return
+        }
+
+        appContext = context.applicationContext
+        installCrashHandler()
+        initialized = true
+    }
+
+    fun logEvent(name: String, params: Map<String, String> = emptyMap()) {
+        val entry = buildEntry("event", name, params)
+        Log.i(TAG, entry)
+        appendToLog(EVENTS_LOG_FILE, entry)
+    }
+
+    fun recordNonFatal(name: String, throwable: Throwable, extras: Map<String, String> = emptyMap()) {
+        val params = extras + mapOf(
+            "message" to (throwable.message ?: "no_message"),
+            "type" to throwable::class.java.simpleName
+        )
+        val entry = buildEntry("non_fatal", name, params)
+        Log.e(TAG, entry, throwable)
+        appendToLog(CRASH_LOG_FILE, entry)
+    }
+
+    private fun installCrashHandler() {
+        val previousHandler = Thread.getDefaultUncaughtExceptionHandler()
+        Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
+            val entry = buildEntry(
+                type = "fatal",
+                name = "uncaught_exception",
+                params = mapOf(
+                    "thread" to thread.name,
+                    "message" to (throwable.message ?: "no_message"),
+                    "type" to throwable::class.java.simpleName
+                )
+            )
+            Log.e(TAG, entry, throwable)
+            appendToLog(CRASH_LOG_FILE, entry)
+            previousHandler?.uncaughtException(thread, throwable)
+        }
+    }
+
+    private fun appendToLog(fileName: String, entry: String) {
+        val context = appContext ?: return
+        runCatching {
+            val directory = File(context.filesDir, "telemetry").apply { mkdirs() }
+            val targetFile = File(directory, fileName)
+            targetFile.appendText(entry + System.lineSeparator())
+        }.onFailure {
+            Log.w(TAG, "Unable to write telemetry log", it)
+        }
+    }
+
+    private fun buildEntry(type: String, name: String, params: Map<String, String>): String {
+        val timestamp = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ", Locale.US).format(Date())
+        val formattedParams = if (params.isEmpty()) {
+            "-"
+        } else {
+            params.entries.joinToString(separator = ",") { "${it.key}=${it.value.sanitize()}" }
+        }
+        return "timestamp=$timestamp type=$type name=$name params=$formattedParams"
+    }
+
+    private fun String.sanitize(): String {
+        return replace(System.lineSeparator(), " ").replace(",", ";")
+    }
+}

--- a/app/src/main/java/programmingtools/MainActivityQR.kt
+++ b/app/src/main/java/programmingtools/MainActivityQR.kt
@@ -114,6 +114,7 @@ class MainActivity : ComponentActivity() {
 
         buttonGenerate.setOnClickListener {
             if (!renderQrFromInputs(showValidationError = true)) {
+                AppTelemetry.logEvent("generate_attempted_empty_text")
                 return@setOnClickListener
             }
         }
@@ -123,12 +124,17 @@ class MainActivity : ComponentActivity() {
             if (bitmapToSave == null) {
                 Toast.makeText(this, getString(R.string.generate_before_saving), Toast.LENGTH_LONG)
                     .show()
+                AppTelemetry.logEvent("save_attempted_without_qr")
                 return@setOnClickListener
             }
 
             val outputBitmap = combineImageAndText(bitmapToSave, editTextSaveText.text.toString().trim())
             pendingSaveBitmap = outputBitmap
             pendingSaveFormat = selectedSaveFormat()
+            AppTelemetry.logEvent(
+                "save_started",
+                mapOf("format" to getString(pendingSaveFormat.labelResId))
+            )
             announceAccessibilityMessage(getString(R.string.save_started_announcement))
             createDocument.launch(defaultFileNameFor(pendingSaveFormat))
         }
@@ -138,9 +144,11 @@ class MainActivity : ComponentActivity() {
             if (bitmapToShare == null) {
                 Toast.makeText(this, getString(R.string.generate_before_sharing), Toast.LENGTH_LONG)
                     .show()
+                AppTelemetry.logEvent("share_attempted_without_qr")
                 return@setOnClickListener
             }
 
+            AppTelemetry.logEvent("share_started")
             announceAccessibilityMessage(getString(R.string.share_started_announcement))
             shareBitmap(combineImageAndText(bitmapToShare, editTextSaveText.text.toString().trim()))
         }
@@ -162,6 +170,7 @@ class MainActivity : ComponentActivity() {
             imageViewQRCode.setImageBitmap(sampleBitmap)
             generatedBitmap = sampleBitmap
             updatePreviewState(hasPreview = true)
+            AppTelemetry.logEvent("sample_generated")
             announceAccessibilityMessage(getString(R.string.sample_generated_announcement))
         }
 
@@ -204,6 +213,7 @@ class MainActivity : ComponentActivity() {
                 Intent.createChooser(shareIntent, getString(R.string.share_qr_chooser_title))
             )
         } catch (e: IOException) {
+            AppTelemetry.recordNonFatal("share_failed", e)
             Toast.makeText(
                 this,
                 getString(R.string.share_image_error, e.localizedMessage),
@@ -227,6 +237,10 @@ class MainActivity : ComponentActivity() {
             contentResolver.openOutputStream(uri)?.use { outputStream ->
                 bitmap.compress(saveFormat.compressFormat, 100, outputStream)
                 runOnUiThread {
+                    AppTelemetry.logEvent(
+                        "image_saved",
+                        mapOf("format" to getString(saveFormat.labelResId))
+                    )
                     Toast.makeText(
                         this,
                         getString(R.string.image_saved_successfully),
@@ -236,6 +250,11 @@ class MainActivity : ComponentActivity() {
                 }
             }
         } catch (e: IOException) {
+            AppTelemetry.recordNonFatal(
+                "save_failed",
+                e,
+                mapOf("format" to getString(saveFormat.labelResId))
+            )
             runOnUiThread {
                 Toast.makeText(
                     this,
@@ -289,6 +308,14 @@ class MainActivity : ComponentActivity() {
         imageViewQRCode.setImageBitmap(qrBitmap)
         generatedBitmap = qrBitmap
         updatePreviewState(hasPreview = true)
+        AppTelemetry.logEvent(
+            "qr_generated",
+            mapOf(
+                "size" to size.toString(),
+                "color" to formatColor(color),
+                "has_caption" to editTextSaveText.text.toString().trim().isNotEmpty().toString()
+            )
+        )
         if (showValidationError) {
             announceAccessibilityMessage(getString(R.string.qr_generated_announcement))
         }
@@ -360,6 +387,7 @@ class MainActivity : ComponentActivity() {
                 val newColor =
                     Color.rgb(redSeekBar.progress, greenSeekBar.progress, blueSeekBar.progress)
                 updateSelectedColor(newColor)
+                AppTelemetry.logEvent("color_changed", mapOf("color" to formatColor(newColor)))
                 announceAccessibilityMessage(
                     getString(R.string.color_changed_announcement, formatColor(newColor))
                 )
@@ -377,6 +405,10 @@ class MainActivity : ComponentActivity() {
             .setTitle(R.string.save_format_picker_title)
             .setSingleChoiceItems(labels, selectedIndex) { dialog, which ->
                 updateSelectedSaveFormat(formats[which])
+                AppTelemetry.logEvent(
+                    "save_format_changed",
+                    mapOf("format" to getString(formats[which].labelResId))
+                )
                 announceAccessibilityMessage(
                     getString(
                         R.string.save_format_changed_announcement,

--- a/app/src/main/java/programmingtools/QRCodeGeniusApp.kt
+++ b/app/src/main/java/programmingtools/QRCodeGeniusApp.kt
@@ -1,0 +1,14 @@
+package com.programmingtools.app
+
+import android.app.Application
+
+class QRCodeGeniusApp : Application() {
+    override fun onCreate() {
+        super.onCreate()
+        AppTelemetry.initialize(this)
+        AppTelemetry.logEvent(
+            "app_opened",
+            mapOf("entry_point" to "application_on_create")
+        )
+    }
+}


### PR DESCRIPTION
Additions:

- a real app-level telemetry layer in [AppTelemetry.kt](app/src/main/java/programmingtools/AppTelemetry.kt:1)
- an application class in [QRCodeGeniusApp.kt](app/src/main/java/programmingtools/QRCodeGeniusApp.kt:1) that initializes telemetry and installs a global uncaught-exception handler
- manifest registration in [AndroidManifest.xml](app/src/main/AndroidManifest.xml:1)
- event logging hooks added to the current screen in [MainActivityQR.kt](app/src/main/java/programmingtools/MainActivityQR.kt:1)

The app now logs events for:

- app open
- QR generation
- sample generation
- save start / save success / save attempted without QR
- share start / share attempted without QR
- save format changes
- color changes

It also records:

- non-fatal save/share failures
- fatal uncaught exceptions through a crash handler

Those logs are written locally under the app’s private files area, which gives you immediate diagnostics without exposing secrets or forcing a third-party dependency yet.

Part of issue #15
