### PR TITLE
adds history tab

### DIFF
--- a/app/src/main/java/programmingtools/MainActivityQR.kt
+++ b/app/src/main/java/programmingtools/MainActivityQR.kt
@@ -21,6 +21,7 @@ import android.view.View
 import android.widget.Button
 import android.widget.EditText
 import android.widget.ImageView
+import android.widget.LinearLayout
 import android.widget.SeekBar
 import android.widget.TextView
 import android.widget.Toast
@@ -45,13 +46,15 @@ import com.google.zxing.qrcode.QRCodeWriter
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import java.text.DateFormat
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
 class MainActivity : ComponentActivity() {
     enum class ScreenMode(@param:StringRes val labelResId: Int) {
         CREATE(R.string.mode_create),
-        SCAN(R.string.mode_scan)
+        SCAN(R.string.mode_scan),
+        HISTORY(R.string.mode_history)
     }
 
     enum class ContentType(@param:StringRes val labelResId: Int) {
@@ -166,16 +169,20 @@ class MainActivity : ComponentActivity() {
     private lateinit var imageViewQRCode: ImageView
     private lateinit var createModeContainer: View
     private lateinit var scanModeContainer: View
+    private lateinit var historyModeContainer: View
     private lateinit var buttonModeCreate: Button
     private lateinit var buttonModeScan: Button
+    private lateinit var buttonModeHistory: Button
     private lateinit var previewViewScanner: PreviewView
     private lateinit var buttonGrantCameraPermission: Button
     private lateinit var buttonResetScan: Button
+    private lateinit var buttonClearHistory: Button
     private lateinit var textViewScanPermissionState: TextView
     private lateinit var textViewScanStatus: TextView
     private lateinit var scanResultContainer: View
     private lateinit var textViewScanResultType: TextView
     private lateinit var textViewScanResultValue: TextView
+    private lateinit var textViewHistoryEmpty: TextView
     private lateinit var buttonScanPrimaryAction: Button
     private lateinit var buttonScanSecondaryAction: Button
     private lateinit var buttonScanUseInCreate: Button
@@ -212,6 +219,7 @@ class MainActivity : ComponentActivity() {
     private lateinit var textViewSelectedColor: TextView
     private lateinit var textViewSelectedBackgroundColor: TextView
     private lateinit var textViewPreviewStatus: TextView
+    private lateinit var historyListContainer: LinearLayout
     private lateinit var textInputContainer: View
     private lateinit var wifiFieldsContainer: View
     private var generatedBitmap: Bitmap? = null
@@ -228,6 +236,7 @@ class MainActivity : ComponentActivity() {
     private var useInCreateAction: (() -> Unit)? = null
     private var cameraProvider: ProcessCameraProvider? = null
     private lateinit var cameraExecutor: ExecutorService
+    private lateinit var scanHistoryStore: ScanHistoryStore
     private var currentEyeStyle: EyeStyle = EyeStyle.CLASSIC
     private var currentCenterBadge: CenterBadge = CenterBadge.NONE
     private var currentDesignStyle: DesignStyle = DesignStyle.MINIMAL
@@ -284,19 +293,24 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
         cameraExecutor = Executors.newSingleThreadExecutor()
+        scanHistoryStore = ScanHistoryStore(this)
 
         createModeContainer = findViewById(R.id.createModeContainer)
         scanModeContainer = findViewById(R.id.scanModeContainer)
+        historyModeContainer = findViewById(R.id.historyModeContainer)
         buttonModeCreate = findViewById(R.id.buttonModeCreate)
         buttonModeScan = findViewById(R.id.buttonModeScan)
+        buttonModeHistory = findViewById(R.id.buttonModeHistory)
         previewViewScanner = findViewById(R.id.previewViewScanner)
         buttonGrantCameraPermission = findViewById(R.id.buttonGrantCameraPermission)
         buttonResetScan = findViewById(R.id.buttonResetScan)
+        buttonClearHistory = findViewById(R.id.buttonClearHistory)
         textViewScanPermissionState = findViewById(R.id.textViewScanPermissionState)
         textViewScanStatus = findViewById(R.id.textViewScanStatus)
         scanResultContainer = findViewById(R.id.scanResultContainer)
         textViewScanResultType = findViewById(R.id.textViewScanResultType)
         textViewScanResultValue = findViewById(R.id.textViewScanResultValue)
+        textViewHistoryEmpty = findViewById(R.id.textViewHistoryEmpty)
         buttonScanPrimaryAction = findViewById(R.id.buttonScanPrimaryAction)
         buttonScanSecondaryAction = findViewById(R.id.buttonScanSecondaryAction)
         buttonScanUseInCreate = findViewById(R.id.buttonScanUseInCreate)
@@ -334,6 +348,7 @@ class MainActivity : ComponentActivity() {
         textViewSelectedColor = findViewById(R.id.textViewSelectedColor)
         textViewSelectedBackgroundColor = findViewById(R.id.textViewSelectedBackgroundColor)
         textViewPreviewStatus = findViewById(R.id.textViewPreviewStatus)
+        historyListContainer = findViewById(R.id.historyListContainer)
         textInputContainer = findViewById(R.id.textInputContainer)
         wifiFieldsContainer = findViewById(R.id.wifiFieldsContainer)
 
@@ -376,6 +391,10 @@ class MainActivity : ComponentActivity() {
             updateScreenMode(ScreenMode.SCAN)
         }
 
+        buttonModeHistory.setOnClickListener {
+            updateScreenMode(ScreenMode.HISTORY)
+        }
+
         buttonGrantCameraPermission.setOnClickListener {
             requestCameraPermissionIfNeeded()
         }
@@ -394,6 +413,10 @@ class MainActivity : ComponentActivity() {
 
         buttonResetScan.setOnClickListener {
             resetScanResult()
+        }
+
+        buttonClearHistory.setOnClickListener {
+            confirmClearHistory()
         }
 
         buttonGenerate.setOnClickListener {
@@ -666,8 +689,11 @@ class MainActivity : ComponentActivity() {
     private fun updateScreenMode(screenMode: ScreenMode) {
         currentScreenMode = screenMode
         val isCreate = screenMode == ScreenMode.CREATE
+        val isScan = screenMode == ScreenMode.SCAN
+        val isHistory = screenMode == ScreenMode.HISTORY
         createModeContainer.visibility = if (isCreate) View.VISIBLE else View.GONE
-        scanModeContainer.visibility = if (isCreate) View.GONE else View.VISIBLE
+        scanModeContainer.visibility = if (isScan) View.VISIBLE else View.GONE
+        historyModeContainer.visibility = if (isHistory) View.VISIBLE else View.GONE
         buttonModeCreate.backgroundTintList =
             ContextCompat.getColorStateList(
                 this,
@@ -676,7 +702,12 @@ class MainActivity : ComponentActivity() {
         buttonModeScan.backgroundTintList =
             ContextCompat.getColorStateList(
                 this,
-                if (isCreate) R.color.button_secondary_bg else R.color.button_primary_bg
+                if (isScan) R.color.button_primary_bg else R.color.button_secondary_bg
+            )
+        buttonModeHistory.backgroundTintList =
+            ContextCompat.getColorStateList(
+                this,
+                if (isHistory) R.color.button_primary_bg else R.color.button_secondary_bg
             )
         buttonModeCreate.setTextColor(
             ContextCompat.getColor(
@@ -687,13 +718,21 @@ class MainActivity : ComponentActivity() {
         buttonModeScan.setTextColor(
             ContextCompat.getColor(
                 this,
-                if (isCreate) R.color.button_secondary_text else R.color.button_primary_text
+                if (isScan) R.color.button_primary_text else R.color.button_secondary_text
+            )
+        )
+        buttonModeHistory.setTextColor(
+            ContextCompat.getColor(
+                this,
+                if (isHistory) R.color.button_primary_text else R.color.button_secondary_text
             )
         )
 
-        if (isCreate) {
+        if (isCreate || isHistory) {
             stopScanner()
-        } else {
+        }
+
+        if (isScan) {
             resetScanResult()
             if (hasCameraPermission()) {
                 updateScanPermissionUi(granted = true)
@@ -703,6 +742,156 @@ class MainActivity : ComponentActivity() {
                 updateScanStatus(getString(R.string.scan_permission_needed))
             }
         }
+
+        if (isHistory) {
+            renderHistory()
+        }
+    }
+
+    private fun renderHistory() {
+        val entries = scanHistoryStore.list()
+        historyListContainer.removeAllViews()
+        textViewHistoryEmpty.visibility = if (entries.isEmpty()) View.VISIBLE else View.GONE
+
+        entries.forEach { entry ->
+            val card = LinearLayout(this).apply {
+                orientation = LinearLayout.VERTICAL
+                background = ContextCompat.getDrawable(this@MainActivity, R.drawable.bg_preview_surface)
+                setPadding(20, 20, 20, 20)
+            }
+            val params = LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                LinearLayout.LayoutParams.WRAP_CONTENT
+            ).apply {
+                topMargin = 16
+            }
+            card.layoutParams = params
+
+            val titleView = TextView(this).apply {
+                text = entry.title
+                setTextColor(ContextCompat.getColor(this@MainActivity, R.color.text_primary))
+                textSize = 16f
+                setTypeface(typeface, android.graphics.Typeface.BOLD)
+            }
+            val metaView = TextView(this).apply {
+                text = getString(
+                    R.string.history_item_meta_format,
+                    entry.type,
+                    DateFormat.getDateTimeInstance().format(entry.timestamp)
+                )
+                setTextColor(ContextCompat.getColor(this@MainActivity, R.color.text_secondary))
+                textSize = 13f
+            }
+            val summaryView = TextView(this).apply {
+                text = entry.summary
+                setTextColor(ContextCompat.getColor(this@MainActivity, R.color.text_secondary))
+                textSize = 14f
+            }
+            val actionRow = LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                val rowParams = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                )
+                rowParams.topMargin = 16
+                layoutParams = rowParams
+            }
+            val useButton = Button(this).apply {
+                text = getString(R.string.history_action_use_in_create)
+                isAllCaps = false
+                backgroundTintList =
+                    ContextCompat.getColorStateList(this@MainActivity, R.color.button_primary_bg)
+                setTextColor(ContextCompat.getColor(this@MainActivity, R.color.button_primary_text))
+                setOnClickListener {
+                    applyScannedRawValueToCreate(entry.rawValue)
+                }
+            }
+            val copyButton = Button(this).apply {
+                text = getString(R.string.history_action_copy)
+                isAllCaps = false
+                backgroundTintList =
+                    ContextCompat.getColorStateList(this@MainActivity, R.color.button_secondary_bg)
+                setTextColor(ContextCompat.getColor(this@MainActivity, R.color.button_secondary_text))
+                setOnClickListener {
+                    copyToClipboard(entry.title, entry.rawValue)
+                }
+            }
+            val deleteButton = Button(this).apply {
+                text = getString(R.string.history_action_delete)
+                isAllCaps = false
+                backgroundTintList =
+                    ContextCompat.getColorStateList(this@MainActivity, R.color.button_secondary_bg)
+                setTextColor(ContextCompat.getColor(this@MainActivity, R.color.button_secondary_text))
+                setOnClickListener {
+                    scanHistoryStore.delete(entry.id)
+                    renderHistory()
+                }
+            }
+            val weightParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+            weightParams.marginEnd = 8
+            useButton.layoutParams = weightParams
+            val copyParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+            copyParams.marginStart = 8
+            copyParams.marginEnd = 8
+            copyButton.layoutParams = copyParams
+            val deleteParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+            deleteParams.marginStart = 8
+            deleteButton.layoutParams = deleteParams
+
+            actionRow.addView(useButton)
+            actionRow.addView(copyButton)
+            actionRow.addView(deleteButton)
+            card.addView(titleView)
+            card.addView(metaView)
+            card.addView(summaryView)
+            card.addView(actionRow)
+            historyListContainer.addView(card)
+        }
+    }
+
+    private fun confirmClearHistory() {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.history_clear_all)
+            .setMessage(R.string.history_clear_confirm)
+            .setPositiveButton(R.string.history_clear_all) { _, _ ->
+                scanHistoryStore.clear()
+                renderHistory()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun addScanToHistory(result: ScanResult, rawValue: String) {
+        when (result) {
+            is ScanResult.Text -> scanHistoryStore.add(
+                type = getString(R.string.scan_result_type_text),
+                title = result.value.take(60),
+                summary = result.value,
+                rawValue = rawValue
+            )
+
+            is ScanResult.Url -> scanHistoryStore.add(
+                type = getString(R.string.scan_result_type_url),
+                title = result.value.take(60),
+                summary = result.value,
+                rawValue = rawValue
+            )
+
+            is ScanResult.Wifi -> scanHistoryStore.add(
+                type = getString(R.string.scan_result_type_wifi),
+                title = result.ssid,
+                summary = getString(
+                    R.string.history_wifi_summary_format,
+                    result.security,
+                    if (result.hidden) getString(R.string.wifi_hidden_yes) else getString(R.string.wifi_hidden_no)
+                ),
+                rawValue = rawValue
+            )
+        }
+    }
+
+    private fun applyScannedRawValueToCreate(rawValue: String) {
+        applyScannedResultToCreate(parseScanResult(rawValue))
     }
 
     private fun hasCameraPermission(): Boolean {
@@ -782,9 +971,11 @@ class MainActivity : ComponentActivity() {
         }
         lastScannedRawValue = rawValue
         lastScanTimestampMs = now
+        val parsedResult = parseScanResult(rawValue)
+        addScanToHistory(parsedResult, rawValue)
         runOnUiThread {
             updateScanStatus(getString(R.string.scan_status_detected))
-            updateScanResult(parseScanResult(rawValue))
+            updateScanResult(parsedResult)
             AppTelemetry.logEvent("qr_scanned")
         }
     }

--- a/app/src/main/java/programmingtools/ScanHistoryStore.kt
+++ b/app/src/main/java/programmingtools/ScanHistoryStore.kt
@@ -1,0 +1,93 @@
+package com.programmingtools.app
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+import java.util.UUID
+
+data class ScanHistoryEntry(
+    val id: String,
+    val rawValue: String,
+    val type: String,
+    val title: String,
+    val summary: String,
+    val timestamp: Long
+)
+
+class ScanHistoryStore(context: Context) {
+    private val preferences =
+        context.getSharedPreferences("scan_history_store", Context.MODE_PRIVATE)
+
+    fun list(): List<ScanHistoryEntry> {
+        val rawJson = preferences.getString(KEY_ENTRIES, "[]").orEmpty()
+        val array = JSONArray(rawJson)
+        return buildList {
+            for (index in 0 until array.length()) {
+                val item = array.optJSONObject(index) ?: continue
+                add(
+                    ScanHistoryEntry(
+                        id = item.optString(KEY_ID),
+                        rawValue = item.optString(KEY_RAW_VALUE),
+                        type = item.optString(KEY_TYPE),
+                        title = item.optString(KEY_TITLE),
+                        summary = item.optString(KEY_SUMMARY),
+                        timestamp = item.optLong(KEY_TIMESTAMP)
+                    )
+                )
+            }
+        }
+    }
+
+    fun add(type: String, title: String, summary: String, rawValue: String) {
+        val current = list().toMutableList()
+        current.removeAll { it.rawValue == rawValue }
+        current.add(
+            0,
+            ScanHistoryEntry(
+                id = UUID.randomUUID().toString(),
+                rawValue = rawValue,
+                type = type,
+                title = title,
+                summary = summary,
+                timestamp = System.currentTimeMillis()
+            )
+        )
+        save(current.take(MAX_ENTRIES))
+    }
+
+    fun delete(id: String) {
+        save(list().filterNot { it.id == id })
+    }
+
+    fun clear() {
+        preferences.edit().putString(KEY_ENTRIES, "[]").apply()
+    }
+
+    private fun save(entries: List<ScanHistoryEntry>) {
+        val array = JSONArray()
+        entries.forEach { entry ->
+            array.put(
+                JSONObject().apply {
+                    put(KEY_ID, entry.id)
+                    put(KEY_RAW_VALUE, entry.rawValue)
+                    put(KEY_TYPE, entry.type)
+                    put(KEY_TITLE, entry.title)
+                    put(KEY_SUMMARY, entry.summary)
+                    put(KEY_TIMESTAMP, entry.timestamp)
+                }
+            )
+        }
+        preferences.edit().putString(KEY_ENTRIES, array.toString()).apply()
+    }
+
+    companion object {
+        private const val KEY_ENTRIES = "entries"
+        private const val KEY_ID = "id"
+        private const val KEY_RAW_VALUE = "raw_value"
+        private const val KEY_TYPE = "type"
+        private const val KEY_TITLE = "title"
+        private const val KEY_SUMMARY = "summary"
+        private const val KEY_TIMESTAMP = "timestamp"
+        private const val MAX_ENTRIES = 50
+    }
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -51,9 +51,21 @@
             android:layout_width="0dp"
             android:layout_height="48dp"
             android:layout_marginStart="6dp"
+            android:layout_marginEnd="6dp"
             android:layout_weight="1"
             android:backgroundTint="@color/button_secondary_bg"
             android:text="@string/mode_scan"
+            android:textAllCaps="false"
+            android:textColor="@color/button_secondary_text" />
+
+        <Button
+            android:id="@+id/buttonModeHistory"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_marginStart="6dp"
+            android:layout_weight="1"
+            android:backgroundTint="@color/button_secondary_bg"
+            android:text="@string/mode_history"
             android:textAllCaps="false"
             android:textColor="@color/button_secondary_text" />
     </LinearLayout>
@@ -84,4 +96,21 @@
 
         <include layout="@layout/content_scan_panel" />
     </LinearLayout>
+
+    <ScrollView
+        android:id="@+id/historyModeContainer"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"
+        android:fillViewport="true"
+        android:visibility="gone">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
+
+            <include layout="@layout/content_history_panel" />
+        </LinearLayout>
+    </ScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/content_history_panel.xml
+++ b/app/src/main/res/layout/content_history_panel.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <TextView
+        android:id="@+id/textViewHistoryTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:accessibilityHeading="true"
+        android:text="@string/history_section_label"
+        android:textColor="@color/text_primary"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/textViewHistoryDescription"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/history_section_description"
+        android:textColor="@color/text_secondary"
+        android:textSize="14sp" />
+
+    <Button
+        android:id="@+id/buttonClearHistory"
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:layout_marginTop="16dp"
+        android:backgroundTint="@color/button_secondary_bg"
+        android:text="@string/history_clear_all"
+        android:textAllCaps="false"
+        android:textColor="@color/button_secondary_text" />
+
+    <TextView
+        android:id="@+id/textViewHistoryEmpty"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:background="@drawable/bg_input_surface"
+        android:padding="14dp"
+        android:text="@string/history_empty"
+        android:textColor="@color/text_secondary"
+        android:textSize="14sp" />
+
+    <LinearLayout
+        android:id="@+id/historyListContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:orientation="vertical" />
+</merge>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -5,6 +5,7 @@
     <string name="screen_subtitle_accessibility">Crea, previsualiza, guarda y comparte códigos QR personalizados.</string>
     <string name="mode_create">Crear</string>
     <string name="mode_scan">Escanear</string>
+    <string name="mode_history">Historial</string>
     <string name="scan_section_label">Escanear códigos QR</string>
     <string name="scan_section_description">Usa la cámara para escanear texto, enlaces y códigos QR de Wi‑Fi.</string>
     <string name="scan_permission_needed">Se necesita acceso a la cámara para escanear códigos QR.</string>
@@ -35,6 +36,16 @@
     <string name="scan_wifi_connect_title">Conectarse a Wi‑Fi</string>
     <string name="scan_wifi_connect_message">Red: %1$s\nSeguridad: %2$s\nOculta: %3$s\n\nSiguiente paso:\nAbre los ajustes de Wi‑Fi, elige esta red y usa la contraseña copiada si hace falta.</string>
     <string name="scan_unknown_result">Código QR escaneado</string>
+    <string name="history_section_label">Historial de escaneos</string>
+    <string name="history_section_description">Los resultados escaneados recientes se guardan localmente en este dispositivo.</string>
+    <string name="history_empty">Aún no hay historial de escaneos.</string>
+    <string name="history_clear_all">Borrar historial</string>
+    <string name="history_clear_confirm">¿Eliminar todo el historial de escaneos guardado en este dispositivo?</string>
+    <string name="history_action_use_in_create">Usar en Crear</string>
+    <string name="history_action_copy">Copiar</string>
+    <string name="history_action_delete">Eliminar</string>
+    <string name="history_item_meta_format">%1$s • %2$s</string>
+    <string name="history_wifi_summary_format">Seguridad: %1$s • Oculta: %2$s</string>
     <string name="content_type_label">Tipo de contenido</string>
     <string name="enter_text_for_qr_code">Ingresa el texto para el código QR</string>
     <string name="text_field_label">Texto para codificar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="screen_subtitle_accessibility">Create, preview, save, and share custom QR codes.</string>
     <string name="mode_create">Create</string>
     <string name="mode_scan">Scan</string>
+    <string name="mode_history">History</string>
     <string name="scan_section_label">Scan QR Codes</string>
     <string name="scan_section_description">Use your camera to scan text, links, and Wi-Fi QR codes.</string>
     <string name="scan_permission_needed">Camera access is needed to scan QR codes.</string>
@@ -35,6 +36,16 @@
     <string name="scan_wifi_connect_title">Connect to Wi-Fi</string>
     <string name="scan_wifi_connect_message">Network: %1$s\nSecurity: %2$s\nHidden: %3$s\n\nNext step:\nOpen Wi-Fi settings, choose this network, and use the copied password if needed.</string>
     <string name="scan_unknown_result">Scanned QR code</string>
+    <string name="history_section_label">Scan History</string>
+    <string name="history_section_description">Recent scanned results are stored locally on this device.</string>
+    <string name="history_empty">No scan history yet.</string>
+    <string name="history_clear_all">Clear History</string>
+    <string name="history_clear_confirm">Remove all saved scan history from this device?</string>
+    <string name="history_action_use_in_create">Use in Create</string>
+    <string name="history_action_copy">Copy</string>
+    <string name="history_action_delete">Delete</string>
+    <string name="history_item_meta_format">%1$s • %2$s</string>
+    <string name="history_wifi_summary_format">Security: %1$s • Hidden: %2$s</string>
     <string name="content_type_label">Content Type</string>
     <string name="enter_text_for_qr_code">Enter text for QR Code</string>
     <string name="text_field_label">Text to Encode</string>


### PR DESCRIPTION
First real `History` mode to the app.

<img width="309" height="482" alt="image" src="https://github.com/user-attachments/assets/8355cdc0-fb2e-4db6-9a92-9e92c518adaf" />

What's in now:
- a third top-level mode: `History`
- persistent local scan history stored on-device across app restarts
- automatic saving of newly scanned results into history
- history cards with:
  - scan title
  - type
  - timestamp
  - summary/details
  - `Use in Create`
  - `Copy`
  - `Delete`
- a `Clear History` action for wiping saved scan history from the device

This means scanned results no longer disappear between sessions, and the history now acts like the bridge between `Scan` and `Create`.

The main additions are:

- [ScanHistoryStore.kt](app/src/main/java/programmingtools/ScanHistoryStore.kt:1)
- [activity_main.xml](app/src/main/res/layout/activity_main.xml:1)
- [content_history_panel.xml](app/src/main/res/layout/content_history_panel.xml:1)
- [MainActivityQR.kt](app/src/main/java/programmingtools/MainActivityQR.kt:1)
- updated strings in [strings.xml](app/src/main/res/values/strings.xml:1) and [values-es/strings.xml](app/src/main/res/values-es/strings.xml:1)

#49 