### PR TITLE
Add home screen widget for quick QR generation from clipboard

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,19 @@
             </intent-filter>
         </activity>
 
+        <receiver
+            android:name=".QuickQrWidgetProvider"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="com.programmingtools.app.action.REFRESH_WIDGET" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/quick_qr_widget_info" />
+        </receiver>
+
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/app/src/main/java/programmingtools/MainActivityQR.kt
+++ b/app/src/main/java/programmingtools/MainActivityQR.kt
@@ -2,6 +2,7 @@ package com.programmingtools.app
 
 import android.Manifest
 import android.app.AlertDialog
+import android.appwidget.AppWidgetManager
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
@@ -180,6 +181,8 @@ class MainActivity : ComponentActivity() {
     }
 
     companion object {
+        private const val EXTRA_WIDGET_TEXT = "extra_widget_text"
+        private const val EXTRA_WIDGET_AUTOGENERATE = "extra_widget_autogenerate"
         private const val STATE_TEXT = "state_text"
         private const val STATE_SCREEN_MODE = "state_screen_mode"
         private const val STATE_CONTENT_TYPE = "state_content_type"
@@ -671,6 +674,8 @@ class MainActivity : ComponentActivity() {
 
             updateScreenMode(currentScreenMode)
         }
+
+        handleWidgetIntent(intent)
     }
 
     private fun shareBitmap(bitmap: Bitmap) {
@@ -725,6 +730,12 @@ class MainActivity : ComponentActivity() {
         if (currentScreenMode == ScreenMode.SCAN && hasCameraPermission()) {
             startScanner()
         }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        handleWidgetIntent(intent)
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
@@ -1046,6 +1057,27 @@ class MainActivity : ComponentActivity() {
                 rawValue = rawValue
             )
         }
+    }
+
+    private fun handleWidgetIntent(intent: Intent?) {
+        val widgetText = intent?.getStringExtra(EXTRA_WIDGET_TEXT)?.trim().orEmpty()
+        val shouldAutogenerate = intent?.getBooleanExtra(EXTRA_WIDGET_AUTOGENERATE, false) == true
+        if (widgetText.isBlank() && !shouldAutogenerate) {
+            return
+        }
+
+        updateScreenMode(ScreenMode.CREATE)
+        updateSelectedContentType(ContentType.TEXT)
+        editText.setText(widgetText)
+        if (shouldAutogenerate && widgetText.isNotBlank()) {
+            renderQrFromInputs(showValidationError = false)
+            Toast.makeText(this, getString(R.string.widget_qr_loaded), Toast.LENGTH_LONG).show()
+        } else if (widgetText.isBlank()) {
+            Toast.makeText(this, getString(R.string.widget_empty_clipboard), Toast.LENGTH_LONG).show()
+        }
+
+        intent?.removeExtra(EXTRA_WIDGET_TEXT)
+        intent?.removeExtra(EXTRA_WIDGET_AUTOGENERATE)
     }
 
     private fun applyScannedRawValueToCreate(rawValue: String) {

--- a/app/src/main/java/programmingtools/QuickQrWidgetProvider.kt
+++ b/app/src/main/java/programmingtools/QuickQrWidgetProvider.kt
@@ -1,0 +1,131 @@
+package com.programmingtools.app
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.graphics.Bitmap
+import android.graphics.Color
+import android.widget.RemoteViews
+
+class QuickQrWidgetProvider : AppWidgetProvider() {
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        appWidgetIds.forEach { widgetId ->
+            updateWidget(context, appWidgetManager, widgetId)
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        if (intent.action == ACTION_REFRESH_WIDGET) {
+            val manager = AppWidgetManager.getInstance(context)
+            val componentName = ComponentName(context, QuickQrWidgetProvider::class.java)
+            manager.getAppWidgetIds(componentName).forEach { widgetId ->
+                updateWidget(context, manager, widgetId)
+            }
+        }
+    }
+
+    private fun updateWidget(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        widgetId: Int
+    ) {
+        val clipboardText = readClipboardText(context).trim()
+        val displayText = if (clipboardText.isBlank()) {
+            context.getString(R.string.widget_clipboard_empty_state)
+        } else {
+            clipboardText
+        }
+
+        val bitmap = createWidgetQrBitmap(context, clipboardText)
+        val views = RemoteViews(context.packageName, R.layout.widget_quick_qr).apply {
+            setTextViewText(R.id.textViewWidgetTitle, context.getString(R.string.widget_title))
+            setTextViewText(R.id.textViewWidgetSubtitle, displayText.take(80))
+            setImageViewBitmap(R.id.imageViewWidgetQr, bitmap)
+
+            setOnClickPendingIntent(
+                R.id.buttonWidgetRefresh,
+                createRefreshPendingIntent(context)
+            )
+            setOnClickPendingIntent(
+                R.id.imageViewWidgetQr,
+                createLaunchPendingIntent(context, clipboardText)
+            )
+            setOnClickPendingIntent(
+                R.id.textViewWidgetSubtitle,
+                createLaunchPendingIntent(context, clipboardText)
+            )
+        }
+
+        appWidgetManager.updateAppWidget(widgetId, views)
+    }
+
+    private fun createWidgetQrBitmap(context: Context, text: String): Bitmap {
+        val widgetText = if (text.isBlank()) {
+            context.getString(R.string.widget_sample_text)
+        } else {
+            text
+        }
+        return QRCodeGenerator().generateQRCode(
+            text = widgetText,
+            width = 320,
+            height = 320,
+            foregroundColor = Color.BLACK,
+            backgroundColor = Color.WHITE,
+            designStyle = MainActivity.DesignStyle.MINIMAL,
+            eyeStyle = MainActivity.EyeStyle.CLASSIC,
+            centerBadge = MainActivity.CenterBadge.NONE,
+            centerLogo = null
+        )
+    }
+
+    private fun createRefreshPendingIntent(context: Context): PendingIntent {
+        val intent = Intent(context, QuickQrWidgetProvider::class.java).apply {
+            action = ACTION_REFRESH_WIDGET
+        }
+        return PendingIntent.getBroadcast(
+            context,
+            1001,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    private fun createLaunchPendingIntent(context: Context, clipboardText: String): PendingIntent {
+        val intent = Intent(context, MainActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            putExtra("extra_widget_text", clipboardText)
+            putExtra("extra_widget_autogenerate", clipboardText.isNotBlank())
+        }
+        return PendingIntent.getActivity(
+            context,
+            1002,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+    }
+
+    private fun readClipboardText(context: Context): String {
+        val clipboardManager =
+            context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager ?: return ""
+        val clipData: ClipData = clipboardManager.primaryClip ?: return ""
+        if (clipData.itemCount == 0) {
+            return ""
+        }
+        return clipData.getItemAt(0).coerceToText(context)?.toString().orEmpty()
+    }
+
+    companion object {
+        private const val ACTION_REFRESH_WIDGET = "com.programmingtools.app.action.REFRESH_WIDGET"
+    }
+}

--- a/app/src/main/res/layout/widget_quick_qr.xml
+++ b/app/src/main/res/layout/widget_quick_qr.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/bg_preview_surface"
+    android:orientation="vertical"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/textViewWidgetTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/widget_title"
+        android:textColor="@color/text_primary"
+        android:textSize="16sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/textViewWidgetSubtitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="6dp"
+        android:maxLines="2"
+        android:text="@string/widget_clipboard_empty_state"
+        android:textColor="@color/text_secondary"
+        android:textSize="12sp" />
+
+    <ImageView
+        android:id="@+id/imageViewWidgetQr"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="12dp"
+        android:layout_weight="1"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/widget_qr_content_description"
+        android:scaleType="fitCenter" />
+
+    <Button
+        android:id="@+id/buttonWidgetRefresh"
+        android:layout_width="match_parent"
+        android:layout_height="44dp"
+        android:layout_marginTop="12dp"
+        android:backgroundTint="@color/button_primary_bg"
+        android:text="@string/widget_refresh"
+        android:textAllCaps="false"
+        android:textColor="@color/button_primary_text" />
+
+</LinearLayout>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -96,6 +96,14 @@
     <string name="feedback_no_comments">No se proporcionaron comentarios adicionales.</string>
     <string name="feedback_email_error">No hay una app de correo disponible para enviar comentarios ahora mismo.</string>
     <string name="feedback_store_error">No se pudo abrir la ficha de Play Store en este momento.</string>
+    <string name="widget_title">QR rápido</string>
+    <string name="widget_description">Genera un código QR desde tu portapapeles sin abrir toda la app.</string>
+    <string name="widget_refresh">Usar portapapeles</string>
+    <string name="widget_clipboard_empty_state">Primero copia un texto y luego toca Usar portapapeles para generar un QR aquí.</string>
+    <string name="widget_sample_text">Widget de QR rápido</string>
+    <string name="widget_qr_content_description">Código QR mostrado en el widget de inicio</string>
+    <string name="widget_qr_loaded">El texto del portapapeles se cargó en el modo Crear.</string>
+    <string name="widget_empty_clipboard">Primero copia algo de texto y luego vuelve a usar el widget.</string>
     <string name="history_action_use_in_create">Usar en Crear</string>
     <string name="history_action_copy">Copiar</string>
     <string name="history_action_delete">Eliminar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -96,6 +96,14 @@
     <string name="feedback_no_comments">No additional comments provided.</string>
     <string name="feedback_email_error">No email app is available to send feedback right now.</string>
     <string name="feedback_store_error">Unable to open the Play Store listing right now.</string>
+    <string name="widget_title">Quick QR</string>
+    <string name="widget_description">Generate a QR code from your clipboard without opening the full app.</string>
+    <string name="widget_refresh">Use Clipboard</string>
+    <string name="widget_clipboard_empty_state">Copy text first, then tap Use Clipboard to generate a QR here.</string>
+    <string name="widget_sample_text">Quick QR Widget</string>
+    <string name="widget_qr_content_description">QR code shown in the home screen widget</string>
+    <string name="widget_qr_loaded">Clipboard text loaded into Create mode.</string>
+    <string name="widget_empty_clipboard">Copy some text first, then use the widget again.</string>
     <string name="history_action_use_in_create">Use in Create</string>
     <string name="history_action_copy">Copy</string>
     <string name="history_action_delete">Delete</string>

--- a/app/src/main/res/xml/quick_qr_widget_info.xml
+++ b/app/src/main/res/xml/quick_qr_widget_info.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/widget_description"
+    android:initialLayout="@layout/widget_quick_qr"
+    android:minWidth="180dp"
+    android:minHeight="220dp"
+    android:previewLayout="@layout/widget_quick_qr"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellWidth="2"
+    android:targetCellHeight="3"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen" />


### PR DESCRIPTION
## Summary

This change adds a home screen widget that lets users quickly generate a QR code from clipboard text without manually going through the full app flow first.

The widget displays a QR preview directly on the home screen, can refresh from the current clipboard contents, and opens the app with the clipboard text already loaded into `Create` mode for editing, saving, or sharing.

This closes #19

## What was added

- a new Android App Widget for quick QR generation
- widget QR generation using the current clipboard text
- a `Use Clipboard` action to refresh the widget from the latest copied content
- a QR preview shown directly inside the widget
- tap-through behavior that opens the app with the clipboard text preloaded in `Create` mode
- fallback handling for empty clipboard content
- English and Spanish localized strings for the widget flow

## Behavior

- if the clipboard contains text, the widget generates a QR code for that content
- if the clipboard is empty, the widget shows an instructional empty state
- tapping the widget opens the app and loads the clipboard text into the main QR creation flow
- this keeps the widget lightweight while still connecting smoothly to the full app experience

## Files changed

- `app/src/main/java/programmingtools/QuickQrWidgetProvider.kt`
- `app/src/main/java/programmingtools/MainActivityQR.kt`
- `app/src/main/AndroidManifest.xml`
- `app/src/main/res/layout/widget_quick_qr.xml`
- `app/src/main/res/xml/quick_qr_widget_info.xml`
- `app/src/main/res/values/strings.xml`
- `app/src/main/res/values-es/strings.xml`

## Verification

Verified with:
```powershell
$env:GRADLE_USER_HOME='.gradle-user'; ./gradlew.bat testDebugUnitTest
```

Result:
- `BUILD SUCCESSFUL`

## Why this closes #19

Issue #19 asked for a home screen widget that allows users to quickly generate QR codes without opening the full app.

This implementation provides that capability by:
- adding a real home screen widget
- generating QR codes directly in the widget from clipboard text
- allowing users to jump into the app only when they want fuller editing or save/share actions

That satisfies the core goal of quick widget-based QR generation.