### PR TITLE
Add cloud-backed scan history

### DIFF
--- a/app/src/main/java/programmingtools/MainActivityQR.kt
+++ b/app/src/main/java/programmingtools/MainActivityQR.kt
@@ -217,6 +217,8 @@ class MainActivity : ComponentActivity() {
     private lateinit var buttonResetScan: Button
     private lateinit var buttonClearHistory: Button
     private lateinit var buttonOpenFeedback: Button
+    private lateinit var buttonExportHistory: Button
+    private lateinit var buttonImportHistory: Button
     private lateinit var buttonTogglePerfPanel: Button
     private lateinit var textViewScanPermissionState: TextView
     private lateinit var textViewScanStatus: TextView
@@ -329,6 +331,19 @@ class MainActivity : ComponentActivity() {
             pendingSaveFormat = SaveFormat.PNG
         }
 
+    private val exportHistoryDocument =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result: ActivityResult ->
+            val uri = result.data?.data ?: return@registerForActivityResult
+            exportHistoryToUri(uri)
+        }
+
+    private val importHistoryDocument =
+        registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+            if (uri != null) {
+                confirmImportHistory(uri)
+            }
+        }
+
     private val requestCameraPermission =
         registerForActivityResult(RequestPermission()) { granted ->
             if (granted) {
@@ -378,6 +393,8 @@ class MainActivity : ComponentActivity() {
         buttonResetScan = findViewById(R.id.buttonResetScan)
         buttonClearHistory = findViewById(R.id.buttonClearHistory)
         buttonOpenFeedback = findViewById(R.id.buttonOpenFeedback)
+        buttonExportHistory = findViewById(R.id.buttonExportHistory)
+        buttonImportHistory = findViewById(R.id.buttonImportHistory)
         buttonTogglePerfPanel = findViewById(R.id.buttonTogglePerfPanel)
         textViewScanPermissionState = findViewById(R.id.textViewScanPermissionState)
         textViewScanStatus = findViewById(R.id.textViewScanStatus)
@@ -514,6 +531,14 @@ class MainActivity : ComponentActivity() {
 
         buttonOpenFeedback.setOnClickListener {
             showFeedbackDialog()
+        }
+
+        buttonExportHistory.setOnClickListener {
+            exportHistoryDocument.launch(createHistoryExportIntent())
+        }
+
+        buttonImportHistory.setOnClickListener {
+            importHistoryDocument.launch(arrayOf("application/json", "text/plain"))
         }
 
         buttonTogglePerfPanel.setOnClickListener {
@@ -992,6 +1017,20 @@ class MainActivity : ComponentActivity() {
             .setPositiveButton(R.string.history_clear_all) { _, _ ->
                 scanHistoryStore.clear()
                 renderHistory()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun confirmImportHistory(uri: Uri) {
+        AlertDialog.Builder(this)
+            .setTitle(R.string.history_import)
+            .setMessage(R.string.history_import_confirm)
+            .setPositiveButton(R.string.history_import_merge) { _, _ ->
+                importHistoryFromUri(uri, replaceExisting = false)
+            }
+            .setNeutralButton(R.string.history_import_replace) { _, _ ->
+                importHistoryFromUri(uri, replaceExisting = true)
             }
             .setNegativeButton(android.R.string.cancel, null)
             .show()
@@ -1952,6 +1991,54 @@ class MainActivity : ComponentActivity() {
             }
         }
         AppTelemetry.logEvent("feedback_rate_store_opened")
+    }
+
+    private fun createHistoryExportIntent(): Intent {
+        return Intent(Intent.ACTION_CREATE_DOCUMENT).apply {
+            addCategory(Intent.CATEGORY_OPENABLE)
+            type = "application/json"
+            putExtra(Intent.EXTRA_TITLE, getString(R.string.history_export_filename))
+        }
+    }
+
+    private fun exportHistoryToUri(uri: Uri) {
+        try {
+            val historyJson = scanHistoryStore.exportJson()
+            contentResolver.openOutputStream(uri)?.use { outputStream ->
+                outputStream.write(historyJson.toByteArray())
+                outputStream.flush()
+            }
+            Toast.makeText(this, getString(R.string.history_export_success), Toast.LENGTH_LONG).show()
+            AppTelemetry.logEvent("history_exported")
+        } catch (e: Exception) {
+            AppTelemetry.recordNonFatal("history_export_failed", e)
+            Toast.makeText(
+                this,
+                getString(R.string.history_export_error, e.localizedMessage ?: ""),
+                Toast.LENGTH_LONG
+            ).show()
+        }
+    }
+
+    private fun importHistoryFromUri(uri: Uri, replaceExisting: Boolean) {
+        try {
+            val rawJson = contentResolver.openInputStream(uri)?.bufferedReader()?.use { it.readText() }
+                .orEmpty()
+            scanHistoryStore.importJson(rawJson, replaceExisting = replaceExisting)
+            renderHistory()
+            Toast.makeText(this, getString(R.string.history_import_success), Toast.LENGTH_LONG).show()
+            AppTelemetry.logEvent(
+                "history_imported",
+                mapOf("replace_existing" to replaceExisting.toString())
+            )
+        } catch (e: Exception) {
+            AppTelemetry.recordNonFatal("history_import_failed", e)
+            Toast.makeText(
+                this,
+                getString(R.string.history_import_error, e.localizedMessage ?: ""),
+                Toast.LENGTH_LONG
+            ).show()
+        }
     }
 
     private fun showWifiConnectDialog(

--- a/app/src/main/java/programmingtools/ScanHistoryStore.kt
+++ b/app/src/main/java/programmingtools/ScanHistoryStore.kt
@@ -16,7 +16,7 @@ data class ScanHistoryEntry(
 
 class ScanHistoryStore(context: Context) {
     private val preferences =
-        context.getSharedPreferences("scan_history_store", Context.MODE_PRIVATE)
+        context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
 
     fun list(): List<ScanHistoryEntry> {
         val rawJson = preferences.getString(KEY_ENTRIES, "[]").orEmpty()
@@ -63,6 +63,40 @@ class ScanHistoryStore(context: Context) {
         preferences.edit().putString(KEY_ENTRIES, "[]").apply()
     }
 
+    fun exportJson(): String {
+        return preferences.getString(KEY_ENTRIES, "[]").orEmpty()
+    }
+
+    fun importJson(rawJson: String, replaceExisting: Boolean) {
+        val importedEntries = parseEntries(rawJson)
+        val merged = if (replaceExisting) {
+            importedEntries
+        } else {
+            val combined = (importedEntries + list()).associateBy { it.rawValue }
+            combined.values.sortedByDescending { it.timestamp }
+        }
+        save(merged.take(MAX_ENTRIES))
+    }
+
+    private fun parseEntries(rawJson: String): List<ScanHistoryEntry> {
+        val array = JSONArray(rawJson)
+        return buildList {
+            for (index in 0 until array.length()) {
+                val item = array.optJSONObject(index) ?: continue
+                add(
+                    ScanHistoryEntry(
+                        id = item.optString(KEY_ID).ifBlank { UUID.randomUUID().toString() },
+                        rawValue = item.optString(KEY_RAW_VALUE),
+                        type = item.optString(KEY_TYPE),
+                        title = item.optString(KEY_TITLE),
+                        summary = item.optString(KEY_SUMMARY),
+                        timestamp = item.optLong(KEY_TIMESTAMP)
+                    )
+                )
+            }
+        }.filter { it.rawValue.isNotBlank() }
+    }
+
     private fun save(entries: List<ScanHistoryEntry>) {
         val array = JSONArray()
         entries.forEach { entry ->
@@ -81,6 +115,7 @@ class ScanHistoryStore(context: Context) {
     }
 
     companion object {
+        const val PREFERENCES_NAME = "scan_history_store"
         private const val KEY_ENTRIES = "entries"
         private const val KEY_ID = "id"
         private const val KEY_RAW_VALUE = "raw_value"

--- a/app/src/main/res/layout/content_history_panel.xml
+++ b/app/src/main/res/layout/content_history_panel.xml
@@ -42,6 +42,26 @@
         android:textColor="@color/button_primary_text" />
 
     <Button
+        android:id="@+id/buttonExportHistory"
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:layout_marginTop="12dp"
+        android:backgroundTint="@color/button_secondary_bg"
+        android:text="@string/history_export"
+        android:textAllCaps="false"
+        android:textColor="@color/button_secondary_text" />
+
+    <Button
+        android:id="@+id/buttonImportHistory"
+        android:layout_width="match_parent"
+        android:layout_height="52dp"
+        android:layout_marginTop="12dp"
+        android:backgroundTint="@color/button_secondary_bg"
+        android:text="@string/history_import"
+        android:textAllCaps="false"
+        android:textColor="@color/button_secondary_text" />
+
+    <Button
         android:id="@+id/buttonTogglePerfPanel"
         android:layout_width="match_parent"
         android:layout_height="52dp"

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -82,6 +82,16 @@
     <string name="history_empty">Aún no hay historial de escaneos.</string>
     <string name="history_clear_all">Borrar historial</string>
     <string name="history_clear_confirm">¿Eliminar todo el historial de escaneos guardado en este dispositivo?</string>
+    <string name="history_export">Exportar historial</string>
+    <string name="history_import">Importar historial</string>
+    <string name="history_import_confirm">Importa el historial de escaneos guardado desde un archivo en la nube o una copia de seguridad del dispositivo. Puedes combinarlo con el historial actual o reemplazarlo por completo.</string>
+    <string name="history_import_merge">Combinar</string>
+    <string name="history_import_replace">Reemplazar</string>
+    <string name="history_export_filename">historial-escaneos.json</string>
+    <string name="history_export_success">El historial de escaneos se exportó correctamente.</string>
+    <string name="history_export_error">No se pudo exportar el historial de escaneos: %1$s</string>
+    <string name="history_import_success">El historial de escaneos se importó correctamente.</string>
+    <string name="history_import_error">No se pudo importar el historial de escaneos: %1$s</string>
     <string name="feedback_open_center">Calificar y opinar</string>
     <string name="feedback_dialog_title">Califica QRCodeGenius</string>
     <string name="feedback_dialog_message">Comparte una calificación rápida y notas opcionales. Puedes enviar comentarios directamente o abrir la ficha de Play Store.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,16 @@
     <string name="history_empty">No scan history yet.</string>
     <string name="history_clear_all">Clear History</string>
     <string name="history_clear_confirm">Remove all saved scan history from this device?</string>
+    <string name="history_export">Export History</string>
+    <string name="history_import">Import History</string>
+    <string name="history_import_confirm">Import saved scan history from a cloud file or device backup. You can merge it with the current history or replace the current history entirely.</string>
+    <string name="history_import_merge">Merge</string>
+    <string name="history_import_replace">Replace</string>
+    <string name="history_export_filename">scan-history.json</string>
+    <string name="history_export_success">Scan history exported successfully.</string>
+    <string name="history_export_error">Could not export scan history: %1$s</string>
+    <string name="history_import_success">Scan history imported successfully.</string>
+    <string name="history_import_error">Could not import scan history: %1$s</string>
     <string name="feedback_open_center">Rate &amp; Feedback</string>
     <string name="feedback_dialog_title">Rate QRCodeGenius</string>
     <string name="feedback_dialog_message">Share a quick star rating and optional notes. You can send feedback directly or open the Play Store listing.</string>

--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -6,8 +6,5 @@
    See https://developer.android.com/about/versions/12/backup-restore
 -->
 <full-backup-content>
-    <!--
-   <include domain="sharedpref" path="."/>
-   <exclude domain="sharedpref" path="device.xml"/>
--->
+    <include domain="sharedpref" path="scan_history_store.xml" />
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -5,15 +5,9 @@
 -->
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <include domain="sharedpref" path="scan_history_store.xml" />
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <include domain="sharedpref" path="scan_history_store.xml" />
     </device-transfer>
-    -->
 </data-extraction-rules>


### PR DESCRIPTION
## Summary

This PR adds a practical cloud synchronization path for scan history by combining Android’s built-in cloud backup support with manual export/import tools in the app.

Instead of requiring a custom backend or account system, scan history can now:

- be included in Android cloud backup and device transfer
- be exported as JSON
- be imported from a saved file
- be merged with existing history or replace it entirely

Closes #21

## What was added

### Cloud backup support

The app now explicitly includes scan history in Android backup and restore configuration.

This allows scan history to participate in:

- Android cloud backup
- device-to-device transfer
- restore flows on supported devices/accounts

Updated files:

- `app/src/main/res/xml/backup_rules.xml`
- `app/src/main/res/xml/data_extraction_rules.xml`

### History export and import

The `History` screen now includes:

- `Export History`
- `Import History`

Users can:

- export scan history to a JSON file
- save that file to a local or cloud-backed provider
- import history from a JSON file later
- choose whether to:
  - merge imported history with existing entries
  - replace existing history entirely

### Storage support

The scan history store now supports:

- exporting stored history as JSON
- importing JSON history back into the app
- merging imported entries while avoiding duplicates by raw value
- preserving the existing history entry structure

Updated file:

- `app/src/main/java/programmingtools/ScanHistoryStore.kt`

### UI updates

The `History` screen now exposes the sync/migration actions directly so the feature is usable without hidden tooling or manual file handling outside the app.

Updated files:

- `app/src/main/java/programmingtools/MainActivityQR.kt`
- `app/src/main/res/layout/content_history_panel.xml`
- `app/src/main/res/values/strings.xml`
- `app/src/main/res/values-es/strings.xml`

## Why this approach

This implementation provides cross-device continuity for scan history without introducing:

- a custom backend
- user accounts
- authentication flows
- server maintenance overhead

It uses Android-native backup where available and also gives users a manual export/import path that works with cloud file providers such as Drive or OneDrive.

## Verification

Verified with:

```powershell
$env:GRADLE_USER_HOME='.gradle-user'; ./gradlew.bat testDebugUnitTest
```

Result:

- `BUILD SUCCESSFUL`
